### PR TITLE
docs: add api discussion docs

### DIFF
--- a/Club-Site.md
+++ b/Club-Site.md
@@ -10,4 +10,4 @@ Having an interlinking history of members and projects could also be useful. Thi
 - Calendar including day/time/info for different events, ways for members to create/edit their own events
 - Wiki integration to include the wiki currently hosted at https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki or to provide a similar service (e.g., by hosting our own wiki software)
 - Blog integration to allow members to post tutorials, projects, etc.
-- Club data API to support creation of alternate clients
+- [Club data API](./api/discussion.adoc) to support creation of alternate clients

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 **Resource Links**
 
-[Getting Started](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/Getting-Started.md)
+[Getting Started](./Getting-Started.md)
 
-[Front-End](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/Front-End-Resources.md)
+[Front-End](./Front-End-Resources.md)
 
-[Back-End](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/Back-End-Resources.md)
+[Back-End](/Back-End-Resources.md)
 
-[General](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/General-Resources.md)
+[General](./General-Resources.md)
 
-[Useful APIs](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/Useful-APIs.md)
+[Useful APIs](./Useful-APIs.md)
 
-[Club Site](https://github.com/Carleton-Web-Dev-Club/CWDC-Wiki/blob/master/Club-Site.md)
+[Club Site](./Club-Site.md)

--- a/api/discussion.adoc
+++ b/api/discussion.adoc
@@ -1,0 +1,76 @@
+# Club Data API
+
+Following outlines routes and endpoints for each that can be offered by Club-data-API v1 
+
+#### Blog
+[%collapsible]
+.Possible endpoints
+====
+* Author
+* Co-author?
+* Category
+* Content
+* Date published
+* Date updated
+* Language
+* Published status
+* Tags
+* Title
+====
+[%collapsible]
+
+#### Events
+[%collapsible]
+.Possible endpoints
+====
+* Date and Time
+** Start
+** End
+* Description
+* Organizer
+* Location
+* Title
+====
+[%collapsible]
+
+#### Projects
+[%collapsible]
+.Possible endpoints
+====
+* Contributors
+* Created date
+* Description
+* Name
+* Status
+====
+[%collapsible]
+
+#### Users
+[%collapsible]
+.Possible endpoints
+====
+* Name 
+* Users
+* Email
+* Role
+* Social accounts
+** Github
+** Discord
+** Steam
+** Twitch
+** Reddit 
+** Twitter
+** Facebook
+** Instagram
+** Website
+** LinkedIn
+** Indeed
+* Organization
+* Profile avatar
+====
+[%collapsible]
+
+
+NOTE: These are just suggestion. All items may or may not be implemented in the initial release.
+
+Join the Discord Channel https://discord.gg/8pJS4zk[#club-site-apigroup] to discuss more.


### PR DESCRIPTION
Added possible routes and endpoints for API as discussed in Discord [#club-site-apigroup](https://discord.gg/8pJS4zk) channel

Please suggest changes and so that we have something to refer for API development.